### PR TITLE
Fix override signature problem.

### DIFF
--- a/source/ddox/entities.d
+++ b/source/ddox/entities.d
@@ -288,7 +288,7 @@ final class FunctionDeclaration : TypedDeclaration {
 class CompositeTypeDeclaration : TypedDeclaration {
 	Declaration[] members;
 
-	override abstract @property DeclarationKind kind();
+	override abstract @property DeclarationKind kind() const;
  
 	this(Entity parent, string name){ super(parent, name); }
 


### PR DESCRIPTION
ddox doesn't build with the current github master of dmd. This fixes one of the problems (a function which overrides a base class function is missing the `const` that the base class function has). There's a whole pile of errors beyond this, but I think that they're errors in vibe-d, because they seem to be in `./.dub/packages/vibe-d/source/vibe/templ/diet.d`. So, this isn't enough to get ddox building with the latest git master of dmd (and this fix at least looks like it's a real bug rather than a regression in dmd), but it does fix one problem with it.
