### PR TITLE
fix 2.066.0 build

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,9 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"vibe-d": "~master",
+		"libevent": "~master",
+		"openssl": "~master",
+		"libev": "~master"
+	}
+}


### PR DESCRIPTION
- workaround missing std.metastrings by using latest vibe-d package
