### PR TITLE
Fix issue 61, problems introduced by changes in libdparse

### DIFF
--- a/source/ddox/entities.d
+++ b/source/ddox/entities.d
@@ -133,7 +133,7 @@ class Entity {
 						ret = res;
 						return false;
 					}
-					return true; 
+					return true;
 				});
 				return ret;
 			}
@@ -241,7 +241,7 @@ class Declaration : Entity {
 	Declaration inheritingDecl;
 	Protection protection = Protection.Public;
 	string[] attributes;
-	int line;
+	size_t line;
 	bool isTemplate;
 	TemplateParameterDeclaration[] templateArgs;
 	string templateConstraint;
@@ -340,7 +340,7 @@ class CompositeTypeDeclaration : Declaration {
 
 	override @property string kindCaption() const { return "Composite type"; }
 	override abstract @property DeclarationKind kind() const;
- 
+
 	this(Entity parent, string name){ super(parent, name); }
 
 	override void iterateChildren(bool delegate(Entity) del)
@@ -508,7 +508,7 @@ final class Type {
 
 		final switch( kind ){
 			case TypeKind.Primitive: return typeName == other.typeName && typeDecl == other.typeDecl;
-			case TypeKind.Pointer: 
+			case TypeKind.Pointer:
 			case TypeKind.Array: return elementType == other.elementType;
 			case TypeKind.StaticArray: return elementType == other.elementType && arrayLength == other.arrayLength;
 			case TypeKind.AssociativeArray: return elementType == other.elementType && keyType == other.keyType;

--- a/source/ddox/parsers/dparse.d
+++ b/source/ddox/parsers/dparse.d
@@ -97,7 +97,7 @@ private struct DParser
 		root.visit!ClassDeclaration((decl){
 			if (decl.baseClass && decl.baseClass.typeDecl && !cast(ClassDeclaration)decl.baseClass.typeDecl)
 				decl.baseClass.typeDecl = null;
-			
+
 			foreach (ref i; decl.derivedInterfaces) {
 				if (i.typeDecl && !decl.baseClass && cast(ClassDeclaration)i.typeDecl) {
 					decl.baseClass = i;
@@ -183,10 +183,10 @@ private struct DParser
 			additional_attribs ~= decl.attributes;
 			return decl.declarations.map!(d => parseDecl(d, parent, additional_attribs)).join();
 		}
-		
+
 		Declaration[] ret;
 		string comment;
-		int line;
+		size_t line;
 		if (auto fd = decl.functionDeclaration) {
 			comment = fd.comment.undecorateComment();
 			line = fd.name.line;
@@ -272,7 +272,7 @@ private struct DParser
 			return null;
 		} else if (auto ad = decl.aliasDeclaration) {
 			comment = ad.comment.undecorateComment();
-			line = ad.name.line;
+			line = ad.identifierList.identifiers[0].line;
 			foreach (ai; ad.initializers) {
 				auto adr = new AliasDeclaration(parent, ai.name.text.idup);
 				adr.targetType = parseType(ai.type, parent);


### PR DESCRIPTION
Issue #61 comes up on linux and seems to be due to libdparse changes. Unfortunately, ddox is used when building phobos docs (http://wiki.dlang.org/Building_DMD).