### PR TITLE
Fix js syntax error for functions with default string parameter

### DIFF
--- a/source/ddox/htmlgenerator.d
+++ b/source/ddox/htmlgenerator.d
@@ -219,7 +219,7 @@ void generateSymbolsJS(OutputStream dst, Package root_package, GeneratorSettings
 		else if (auto adecl = cast(AliasDeclaration)ent) attributes = adecl.attributes;
 		else if (auto tdecl = cast(TypedDeclaration)ent) attributes = tdecl.type.attributes;
 		attributes = attributes.map!(a => a.startsWith("@") ? a[1 .. $] : a).array;
-		(&rng).formattedWrite(`{name: "%s", kind: "%s", path: "%s", attributes: %s},`, ent.qualifiedName, kind, link_to(ent), attributes);
+		(&rng).formattedWrite(`{name: '%s', kind: "%s", path: '%s', attributes: %s},`, ent.qualifiedName, kind, link_to(ent), attributes);
 		rng.put('\n');
 	}
 


### PR DESCRIPTION
If a function looked like this:

    path.to.module.toStaticArray(ulong n, D, char[] func = "toStaticArray", T...)

symbols.js would break because it would write:

    {name: "path.to.module.toStaticArray(ulong n, D, char[] func = "toStaticArray", T...)", [..] }

Which results in a syntax error. This commit uses 's instead for name and path
in the symbols.js file.