### PR TITLE
Fix infinite loop when finding base class

### DIFF
--- a/source/ddox/processors/inherit.d
+++ b/source/ddox/processors/inherit.d
@@ -73,12 +73,15 @@ void inheritDocs(Package root)
 	void scanClass(ClassDeclaration decl)
 	{
 		if (decl in visited) return;
+
+		visited[decl] = true;
+
 		if (decl.baseClass && decl.baseClass.typeDecl) scanClass(cast(ClassDeclaration)decl.baseClass.typeDecl);
+
 		foreach (i; decl.derivedInterfaces)
 			if (i.typeDecl)
 				scanInterface(cast(InterfaceDeclaration)i.typeDecl);
 
-		visited[decl] = true;
 		if (decl.baseClass && decl.baseClass.typeDecl)
 			inheritMembers(decl, (cast(ClassDeclaration)decl.baseClass.typeDecl).members, decl.baseClass.typeDecl);
 		foreach (i; decl.derivedInterfaces)


### PR DESCRIPTION
I had the case that decl.baseClass.typeDecl is decl, moving the visited
assignment up fixed it (adding a check for decl !is decl.baseClass.typeDecl did
NOT fix it, so it might be a bit more complex)