### PR TITLE
Update reference to libdparse

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
 	],
 	"dependencies": {
   		"vibe-d": "~>0.7.22",
-		"libdparse": {"optional": true, "version": "~>0.1.1"}
+		"libdparse": {"optional": true, "version": "~>0.2.0"}
  	},
  	"versions": ["JsonLineNumbers"],
  	"configurations": [

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"libdparse": "0.1.1",
+		"libdparse": "0.2.0",
 		"memutils": "~master",
 		"libevent": "2.0.1+2.0.16",
 		"vibe-d": "0.7.23-beta.1+commit.2.gb9b89bf",

--- a/source/ddox/parsers/dparse.d
+++ b/source/ddox/parsers/dparse.d
@@ -393,7 +393,7 @@ private struct DParser
 					ret = Type.makeFunction(ret, parseParameters(sf.parameters, null).map!(p => p.type).array);
 				else ret = Type.makeDelegate(ret, parseParameters(sf.parameters, null).map!(p => p.type).array);
 			}
-			else if (sf.star) ret = Type.makePointer(ret);
+			else if (sf.star.type != dlex.tok!"") ret = Type.makePointer(ret);
 			else if (sf.array) {
 				if (sf.type) ret = ret.makeAssociativeArray(ret, parseType(sf.type, scope_));
 				else if (sf.low) ret = ret.makeStaticArray(ret, formatNode(sf.low));


### PR DESCRIPTION
A new version of libdparse was recently released with 2.067 syntax.
The only breaking change was the change of the 'star' member, in https://github.com/Hackerpilot/libdparse/commit/3a6705f4576c9e6ac1586c1e3e7434c2a624e8ed