### PR TITLE
update dependencies to fix compilation with dmd-2.072.x

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,6 +6,6 @@ license "MIT"
 
 dependency "vibe-d:web" version="~>0.7.28"
 dependency "hyphenate" version="~>1.1.0"
-dependency "libdparse" version="~>0.6.0"
+dependency "libdparse" version="~>0.7.0-beta.2"
 
 versions "JsonLineNumbers"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -4,10 +4,10 @@
 		"experimental_allocator": "2.70.0-b1",
 		"hyphenate": "1.1.1",
 		"libasync": "0.7.9",
-		"libdparse": "0.6.0",
+		"libdparse": "0.7.0-beta.2",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.1+2.0.16",
-		"memutils": "0.4.6",
+		"memutils": "0.4.7",
 		"openssl": "1.1.4+1.0.1g",
 		"vibe-d": "0.7.29"
 	}

--- a/source/ddox/parsers/dparse.d
+++ b/source/ddox/parsers/dparse.d
@@ -12,6 +12,7 @@ import ddox.entities;
 import dparse = dparse.parser;
 import dlex = dparse.lexer;
 import dformat = dparse.formatter;
+import dparse.rollback_allocator : RollbackAllocator;
 
 import std.algorithm;
 import std.conv;
@@ -128,7 +129,8 @@ private struct DParser
 		config.stringBehavior = dlex.StringBehavior.source;
 		dlex.StringCache cache = dlex.StringCache(1024 * 4);
 		auto tokens = dlex.getTokensForParser(cast(ubyte[])std.file.read(filename), config, &cache).array;
-		auto dmod = dparse.parseModule(tokens, filename);
+                RollbackAllocator rba;
+		auto dmod = dparse.parseModule(tokens, filename, &rba);
 
 		Module mod;
 		if (!dmod.moduleDeclaration) {


### PR DESCRIPTION
- conflicting std.x.allocator dependency in libdparse got dropped
- also fixes #134