### PR TITLE
Add runnable unittest marker for ddox - fixes #137

### DIFF
--- a/source/ddox/main.d
+++ b/source/ddox/main.d
@@ -234,7 +234,7 @@ int cmdFilterDocs(string[] args)
 					if (last_decl["comment"].opt!string.empty) {
 						writefln("Warning: Cannot add documented unit test %s to %s, which is not documented.", name, last_decl["name"].opt!string);
 					} else {
-						last_decl["comment"] ~= format("Example:\n%s\n---\n%s\n---\n", comment.strip, source);
+						last_decl["comment"] ~= format("Example:\n%s$(DDOX_UNITTEST \n---\n%s\n---\n)\n", comment.strip, source);
 					}
 				} catch (Exception e) {
 					writefln("Failed to add documented unit test %s:%s as example: %s",


### PR DESCRIPTION
Literally the simplest solution for #137 - whenever I tried to wrap the magic `---` it broke the comment or led to the same result as here:

```html
<section>
    <h3>Example</h3>
    <p>
        <span class="dlang_runnable"></span>
    </p>
    <pre class="code">
...
```

Maybe my Ddoc skills aren't that well, but OTOH a similar hack is used for [dlang.org](https://github.com/dlang/dlang.org/blob/master/dlang.org.ddoc#L112).
However, @s-ludwig if you have a smarter solution - please let me know ;-)

1) How can I add a test? I didn't see any script that executes the stuff in `tests`
2) Should I provide default definition for this marker or should we better place this in the `ddox.doc` file at dlang.org