### PR TITLE
add --html-style option

### DIFF
--- a/source/ddox/main.d
+++ b/source/ddox/main.d
@@ -132,6 +132,7 @@ int setupGeneratorInput(ref string[] args, out GeneratorSettings gensettings, ou
 		"sitemap-url", &sitemapurl,
 		"std-macros", &macrofiles,
 		"enum-member-pages", &gensettings.enumMemberPages,
+		"html-style", &gensettings.htmlOutputStyle,
 		);
 	gensettings.siteUrl = URL(sitemapurl);
 
@@ -345,6 +346,7 @@ Use <COMMAND> -h|--help to get detailed usage information for a command.
     --decl-sort=MODE       The sort order used for declaration lists
     --web-file-dir=DIR     Make files from dir available on the served site
     --enum-member-pages    Generate a single page per enum member
+    --html-style=STYLE     Sets the HTML output style, either compact (default) or pretty.
     --hyphenate            hyphenate text
  -h --help                 Show this help
 
@@ -374,6 +376,7 @@ protectionInheritanceName
                            This option is useful on case insensitive file
                            systems.
     --enum-member-pages    Generate a single page per enum member
+    --html-style=STYLE     Sets the HTML output style, either compact (default) or pretty.
     --hyphenate            hyphenate text
  -h --help                 Show this help
 

--- a/source/ddox/main.d
+++ b/source/ddox/main.d
@@ -111,33 +111,31 @@ int cmdServeTest(string[] args)
 
 int setupGeneratorInput(ref string[] args, out GeneratorSettings gensettings, out Package pack)
 {
+	gensettings = new GeneratorSettings;
+	auto docsettings = new DdoxSettings;
+
 	string[] macrofiles;
 	string[] overridemacrofiles;
-	NavigationType navtype = NavigationType.ModuleTree;
-	string[] pack_order;
 	string sitemapurl = "http://127.0.0.1/";
-	MethodStyle file_name_style = MethodStyle.unaltered;
-	SortMode modsort = SortMode.protectionName;
-	SortMode declsort = SortMode.protectionInheritanceName;
 	bool lowercasenames;
 	bool hyphenate;
-	bool singlepageenum;
 	getopt(args,
 		//config.passThrough,
-		"decl-sort", &declsort,
-		"file-name-style", &file_name_style,
+		"decl-sort", &docsettings.declSort,
+		"file-name-style", &gensettings.fileNameStyle,
 		"hyphenate", &hyphenate,
 		"lowercase-names", &lowercasenames,
-		"module-sort", &modsort,
-		"navigation-type", &navtype,
+		"module-sort", &docsettings.moduleSort,
+		"navigation-type", &gensettings.navigationType,
 		"override-macros", &overridemacrofiles,
-		"package-order", &pack_order,
+		"package-order", &docsettings.packageOrder,
 		"sitemap-url", &sitemapurl,
 		"std-macros", &macrofiles,
-		"enum-member-pages", &singlepageenum,
+		"enum-member-pages", &gensettings.enumMemberPages,
 		);
+	gensettings.siteUrl = URL(sitemapurl);
 
-	if (lowercasenames) file_name_style = MethodStyle.lowerCase;
+	if (lowercasenames) gensettings.fileNameStyle = MethodStyle.lowerCase;
 
 	if( args.length < 3 ){
 		showUsage(args);
@@ -149,17 +147,8 @@ int setupGeneratorInput(ref string[] args, out GeneratorSettings gensettings, ou
 	if (hyphenate) enableHyphenation();
 
 	// parse the json output file
-	auto docsettings = new DdoxSettings;
-	docsettings.packageOrder = pack_order;
-	docsettings.moduleSort = modsort;
-	docsettings.declSort = declsort;
 	pack = parseDocFile(args[2], docsettings);
 
-	gensettings = new GeneratorSettings;
-	gensettings.siteUrl = URL(sitemapurl);
-	gensettings.navigationType = navtype;
-	gensettings.fileNameStyle = file_name_style;
-	gensettings.enumMemberPages = singlepageenum;
 	return 0;
 }
 

--- a/source/ddox/settings.d
+++ b/source/ddox/settings.d
@@ -8,6 +8,7 @@
 module ddox.settings;
 
 import vibe.inet.url;
+import diet.html : HTMLOutputStyle;
 public import vibe.web.common : MethodStyle;
 
 enum SortMode {
@@ -50,6 +51,8 @@ class GeneratorSettings {
 	MethodStyle fileNameStyle = MethodStyle.unaltered;
 	/// Enables syntax highlighting for inline code
 	bool highlightInlineCode = true;
+	/// Select HTML style (e.g. compact, pretty)
+	HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.compact;
 
 	/// Creates a page per enum member instead of putting everything into a single table.
 	bool enumMemberPages;


### PR DESCRIPTION
- allow to pretty-print HTML output (useful for tests and development)
- quite suboptimal due to https://github.com/rejectedsoftware/diet-ng/issues/33