### PR TITLE
Default to --html-style=pretty.

### DIFF
--- a/source/ddox/main.d
+++ b/source/ddox/main.d
@@ -346,7 +346,8 @@ Use <COMMAND> -h|--help to get detailed usage information for a command.
     --decl-sort=MODE       The sort order used for declaration lists
     --web-file-dir=DIR     Make files from dir available on the served site
     --enum-member-pages    Generate a single page per enum member
-    --html-style=STYLE     Sets the HTML output style, either compact (default) or pretty.
+    --html-style=STYLE     Sets the HTML output style, either pretty (default)
+                           or compact.
     --hyphenate            hyphenate text
  -h --help                 Show this help
 
@@ -376,7 +377,8 @@ protectionInheritanceName
                            This option is useful on case insensitive file
                            systems.
     --enum-member-pages    Generate a single page per enum member
-    --html-style=STYLE     Sets the HTML output style, either compact (default) or pretty.
+    --html-style=STYLE     Sets the HTML output style, either pretty (default)
+                           compact or .
     --hyphenate            hyphenate text
  -h --help                 Show this help
 

--- a/source/ddox/settings.d
+++ b/source/ddox/settings.d
@@ -52,7 +52,7 @@ class GeneratorSettings {
 	/// Enables syntax highlighting for inline code
 	bool highlightInlineCode = true;
 	/// Select HTML style (e.g. compact, pretty)
-	HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.compact;
+	HTMLOutputStyle htmlOutputStyle = HTMLOutputStyle.pretty;
 
 	/// Creates a page per enum member instead of putting everything into a single table.
 	bool enumMemberPages;


### PR DESCRIPTION
This used to be the default up until the switch to diet-ng and the compact style makes the output difficult to compare or debug, while the space savings are usually not a practical concern (may be different for large volume services like docs on code.dlang.org, but gzip would solve that as well).