### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: d
-d: dmd-2.078.1
+d: dmd-2.085.1
 addons:
   apt:
     packages:

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,20 +1,20 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"botan": "1.12.10",
+		"botan": "1.12.12",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.5.0",
-		"eventcore": "0.8.35",
-		"hyphenate": "1.1.1",
-		"libasync": "0.8.3",
-		"libdparse": "0.8.7",
+		"diet-ng": "1.6.1",
+		"eventcore": "0.8.48",
+		"hyphenate": "1.1.2",
+		"libasync": "0.8.5",
+		"libdparse": "0.8.8",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "0.4.11",
-		"mir-linux-kernel": "1.0.0",
+		"memutils": "1.0.2",
+		"mir-linux-kernel": "1.0.1",
 		"openssl": "1.1.6+1.0.1g",
-		"stdx-allocator": "2.77.2",
-		"taggedalgebraic": "0.10.11",
-		"vibe-core": "1.4.0",
-		"vibe-d": "0.8.4"
+		"stdx-allocator": "2.77.5",
+		"taggedalgebraic": "0.11.8",
+		"vibe-core": "1.8.1",
+		"vibe-d": "0.8.6"
 	}
 }

--- a/tests/issue196_double_auto/docs/test.html
+++ b/tests/issue196_double_auto/docs/test.html
@@ -40,7 +40,7 @@ $('#symbolSearchPane').show();</script>
 					<tr>
 						<td>
 							<code>
-								<a id="bar" class="public" href="./test/bar.html">bar</a><span class="decoration">(a, b)</span>
+								<a id="bar" class="public" href="./test/bar.html">bar</a><span class="tableEntryAnnotation">(a, b)</span>
 							</code>
 						</td>
 						<td></td>
@@ -48,7 +48,7 @@ $('#symbolSearchPane').show();</script>
 					<tr>
 						<td>
 							<code>
-								<a id="baz" class="public" href="./test/baz.html">baz</a><span class="decoration">(a, b, what)</span>
+								<a id="baz" class="public" href="./test/baz.html">baz</a><span class="tableEntryAnnotation">(a, b, what)</span>
 							</code>
 						</td>
 						<td></td>
@@ -56,7 +56,7 @@ $('#symbolSearchPane').show();</script>
 					<tr>
 						<td>
 							<code>
-								<a id="foo" class="public property" href="./test/foo.html">foo</a><span class="decoration">(a, b)</span>
+								<a id="foo" class="public property" href="./test/foo.html">foo</a><span class="tableEntryAnnotation">(a, b)</span>
 							</code>
 						</td>
 						<td></td>


### PR DESCRIPTION
Required for e.g. https://github.com/dlang/ci/pull/409 as new Buildkite agents come with OpenSSL 1.1 only and Vibe.d 0.8.4 doesn't do the auto-detect just yet.