### PR TITLE
Update hyphenate to v1.1.3

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -5,7 +5,7 @@
 		"botan-math": "1.0.3",
 		"diet-ng": "1.7.4",
 		"eventcore": "0.9.9",
-		"hyphenate": "1.1.2",
+		"hyphenate": "1.1.3",
 		"libasync": "0.8.6",
 		"libdparse": "0.15.4",
 		"libevent": "2.0.2+2.0.16",


### PR DESCRIPTION
New version no longer makes use of deprecated D1 operators, which are due for removal in dlang/dmd#12902.