### PR TITLE
Upgrade dependencies to support Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                dc: [dmd-latest, ldc-latest, ldc-1.17.0]
+                dc: [dmd-latest, ldc-latest, ldc-1.20.0]
                 arch: [x86, x86_64]
 
         runs-on: ${{ matrix.os }}

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -3,7 +3,7 @@
 	"versions": {
 		"botan": "1.12.19",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.8.0",
+		"diet-ng": "1.8.1",
 		"eventcore": "0.9.20",
 		"hyphenate": "1.1.3",
 		"libasync": "0.8.6",
@@ -11,10 +11,10 @@
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "1.0.4",
 		"mir-linux-kernel": "1.0.1",
-		"openssl": "1.1.6+1.0.1g",
+		"openssl": "3.2.2",
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.22",
 		"vibe-core": "1.22.4",
-		"vibe-d": "0.9.4"
+		"vibe-d": "0.9.5"
 	}
 }


### PR DESCRIPTION
@s-ludwig : Could we get a new release with this ? DDOX on Ubuntu 22.04 (which is becoming latest on Github Actions) is broken.